### PR TITLE
Fixes type error of CofreeF and a typo

### DIFF
--- a/blog/posts/monad_transformers_and_comonad_transformers.md
+++ b/blog/posts/monad_transformers_and_comonad_transformers.md
@@ -478,7 +478,7 @@ data Cofree f a = a :< f (Cofree f a)
 ```
 to `CofreeT`
 ```haskell
-data CofreeF f a b = a :< Cofree f b
+data CofreeF f a b = a :< f b
 data CofreeT f w a = CoFreeT { runCofreeT :: w (CofreeF f a (CofreeT f w a)) }
 ```
 
@@ -709,7 +709,7 @@ although we could just as easily have used a pure version of `mkCoAdder` stacked
 
 We've now factored out the state and environment from the interpreter, but there are still aspects of both the DSL and the interpreter which are more strongly coupled than they need to be.
 
-We'll start to deal with this in the [next post](/posts/coproducts_for_free_and_products_for_cofree.html), where we'll use coproducts to break out the orthogonal parts of the the DSL and products to make a similar change to the interpreter.
+We'll start to deal with this in the [next post](/posts/coproducts_for_free_and_products_for_cofree.html), where we'll use coproducts to break out the orthogonal parts of the DSL and products to make a similar change to the interpreter.
 After that we'll have a deeper look at making use of various effects in conjunction with free and cofree.
 
 [Questions? Comments?](http://www.reddit.com/r/haskell/comments/39vaqj/monad_transformers_and_comonad_transformers/)


### PR DESCRIPTION
`data CofreeF f a b = a :< Cofree f b`
->
`data CofreeF f a b = a :< f b`
