### PR TITLE
fix a name clash

### DIFF
--- a/code/cofun-network/src/Util/Network/Interpreter.hs
+++ b/code/cofun-network/src/Util/Network/Interpreter.hs
@@ -15,7 +15,7 @@ import Util.Network.Errors
 import Util.Pairing
 
 import Control.Comonad
-import Control.Comonad.Trans.Cofree
+import Control.Comonad.Trans.Cofree hiding (transCofreeT)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -50,4 +50,3 @@ runInterpreter :: HostName -> ServiceName -> ReaderT Socket (ExceptT NetError IO
 runInterpreter host service x =
   serve (Host host) service $ \(sock, _) ->
      void . runExceptT . flip runReaderT sock $ x
-


### PR DESCRIPTION
I am trying to go through your code and see if I can translate it to Scala. (I am a begineer with Haskell)

But I got the following error when 

``` bash
19:10:15 - ~/Programming/Haskell/cofun/code/cofun-network
hjs@bblfish[0] (master)$ cabal install 
Resolving dependencies...
Notice: installing into a sandbox located at
/Volumes/Dev/Programming/Haskell/cofun/code/sandbox
Configuring cofun-network-0.1.0.0...
Building cofun-network-0.1.0.0...
Failed to install cofun-network-0.1.0.0
Build log ( /Volumes/Dev/Programming/Haskell/cofun/code/sandbox/logs/cofun-network-0.1.0.0.log ):
Configuring cofun-network-0.1.0.0...
Building cofun-network-0.1.0.0...
Preprocessing library cofun-network-0.1.0.0...
[5 of 5] Compiling Util.Network.Interpreter ( src/Util/Network/Interpreter.hs, dist/dist-sandbox-f1021f34/build/Util/Network/Interpreter.o )

src/Util/Network/Interpreter.hs:44:41:
    Ambiguous occurrence ‘transCofreeT’
    It could refer to either ‘Util.Network.Interpreter.transCofreeT’,
                             defined at src/Util/Network/Interpreter.hs:44:1
                          or ‘Control.Comonad.Trans.Cofree.transCofreeT’,
                             imported from ‘Control.Comonad.Trans.Cofree’ at src/Util/Network/Interpreter.hs:18:1-35

src/Util/Network/Interpreter.hs:47:58:
    Ambiguous occurrence ‘transCofreeT’
    It could refer to either ‘Util.Network.Interpreter.transCofreeT’,
                             defined at src/Util/Network/Interpreter.hs:44:1
                          or ‘Control.Comonad.Trans.Cofree.transCofreeT’,
                             imported from ‘Control.Comonad.Trans.Cofree’ at src/Util/Network/Interpreter.hs:18:1-35
cabal: Error: some packages failed to install:
cofun-network-0.1.0.0 failed during the building phase. The exception was:
ExitFailure 1
```

The simple commit seems to fix it, though I am not 100% sure if that is right.
